### PR TITLE
Split key-value pairs on first occurrence of "="

### DIFF
--- a/flask_dotenv.py
+++ b/flask_dotenv.py
@@ -34,7 +34,7 @@ class DotEnv(object):
     def __import_vars(self, env_file):
         with open(env_file, "r") as f:
             for line in f:
-                key, val = line.strip().split('=')
+                key, val = line.strip().split('=', 1)
                 if not callable(val):
                     if self.verbose_mode:
                         if key in self.app.config:


### PR DESCRIPTION
This handles cases where the value of a env key contains one or more "=" signs such as `DATABASE_URL='postgresql://user:password@localhost:5432/todo?sslmode=disable'.`. Without this, an error is thrown `ValueError: too many values to unpack`
