### PR TITLE
Create `eval` for ast literal value as optional feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,13 @@ Flask-DotEnv
 |
 
 
-`Flask-DotEnv` will directly set (add, update and map as alias) variable from ``.env`` file,
+`Flask-DotEnv` will directly set (add, update, map as alias and eval as literal) variable from ``.env`` file,
 and cast to Python native types as appropriate.
+
+(optional)
+
+* ``alias()`` makes alias var
+* ``eval()`` evaluate var to literal (via ast)
 
 
 Install
@@ -94,7 +99,8 @@ You can pass ``.env`` file path as second argument of ``init_app()``.
 
     * Overwriting an existing config var: SECRET_KEY
     * Setting an entirely new config var: DEVELOPMENT_DATABASE_URL
-    * Mapping a specified var as a alias: DEVELOPMENT_DATABASE_URL => SQLALCHEMY_DATABASE_URI
+    * Casting a specified var as literal: MAIL_PORT => <class 'int'>
+    * Mapping a specified var as a alias: DEVELOPMENT_DATABASE_URL -> SQLALCHEMY_DATABASE_URI
     ...
 
 **********
@@ -138,6 +144,38 @@ This is example usage of ``alias``:
     config = {
         'development': DevelopmentConfig
     }
+
+
+**********
+Eval
+**********
+
+``eval()`` method takes a dict argment.
+
+::
+
+    env.eval(keys={
+      'MAIL_PORT': int,
+      'SETTINGS': dict
+    })
+
+This is example usage of ``eval``:
+
+::
+
+    class Config:
+        SECRET_KEY = ":'("
+        ...
+
+        @classmethod
+        def init_app(self, app)
+            env = DotEnv()
+            env.init_app(app)
+
+            # this will be evaluated via ast.literal_eval
+            env.eval(keys={
+                MAIL_PORT: int
+            })
 
 
 Development

--- a/flask_dotenv.py
+++ b/flask_dotenv.py
@@ -24,6 +24,8 @@ class DotEnv(object):
     def init_app(self, app, env_file=None, verbose_mode=False):
         if self.app is None:
             self.app = app
+        self.verbose_mode = verbose_mode
+
         if env_file is None:
             env_file = os.path.join(os.getcwd(), ".env")
         if not os.path.exists(env_file):
@@ -35,33 +37,62 @@ class DotEnv(object):
         with open(env_file, "r") as f:
             for line in f:
                 try:
-                    key, value = line.strip().split('=', 1)
+                    key, val = line.strip().split('=', 1)
                 except ValueError:  # Take care of blank or comment lines
                     pass
-                try:
-                    val = ast.literal_eval(value)
-                    if self.verbose_mode:
-                        print(" * {0}: value {1} of type {2} cast to {3}".format(key, value, type(value), type(val)))
-                except (ValueError, SyntaxError):
-                    if self.verbose_mode:
-                        print(" * {0}: Couldn't evaluate syntax of value on .env line:\n     {1}\n"
-                              "   Importing as string value.".format(key, line.strip()))
-                    val = re.sub(r"\A[\"']|[\"']\Z", "", value)
                 finally:
                     if not callable(val):
                         if self.verbose_mode:
                             if key in self.app.config:
-                                msg = " * Overwriting an existing config var: {0}"
+                                print(
+                                    " * Overwriting an existing config var:"
+                                    " {0}".format(key))
                             else:
-                                msg = " * Setting an entirely new config var: {0}"
-                            print(msg.format(key))
-                        self.app.config[key] = val
+                                print(
+                                    " * Setting an entirely new config var:"
+                                    " {0}".format(key))
+                        self.app.config[key] = re.sub(
+                            r"\A[\"']|[\"']\Z", "", val)
+
+    def eval(self, keys):
+        """
+        Examples:
+            Specify type literal for key.
+
+            >>> env.eval({MAIL_PORT: int})
+        """
+        for k, v in keys.items():
+            if k in self.app.config:
+                try:
+                    val = ast.literal_eval(self.app.config[k])
+                    if type(val) == v:
+                        if self.verbose_mode:
+                            print(
+                                " * Casting a specified var as literal:"
+                                " {0} => {1}".format(k, v)
+                            )
+                        self.app.config[k] = val
+                    else:
+                        print(
+                            " ! Does not match with specified type:"
+                            " {0} => {1}".format(k, v))
+                except (ValueError, SyntaxError):
+                    print(" ! Could not evaluate as literal type:"
+                          " {0} => {1}".format(k, v))
 
     def alias(self, maps):
+        """
+        Examples:
+            Make alias var -> as.
+
+            >>> env.alias(maps={
+              'TEST_DATABASE_URL': 'SQLALCHEMY_DATABASE_URI',
+              'TEST_HOST': 'HOST'
+            })
+        """
         for k, v in maps.items():
             if self.verbose_mode:
                 print(
                     " * Mapping a specified var as a alias:"
-                    " {0} => {1}".format(v, k)
-                )
+                    " {0} -> {1}".format(v, k))
             self.app.config[v] = self.app.config[k]

--- a/tests/.env
+++ b/tests/.env
@@ -6,4 +6,4 @@ DATABASE_URL='postgresql://user:password@localhost/production?sslmode=require'
 # Testing that comments and blank lines are ignored...
 
 FEATURES={'DotEnv': True}
-NUMERIC=15
+PORT_NUMBER=15

--- a/tests/flask_dotenv_test.py
+++ b/tests/flask_dotenv_test.py
@@ -51,9 +51,9 @@ class DotEnvTestCase(unittest.TestCase):
 
     def test_warning_if_env_file_is_missing(self):
         with warnings.catch_warnings(record=True) as w:
-            self.env.init_app(self.app, "/does/not/exist/.env")
+            self.env.init_app(self.app, '/does/not/exist/.env')
             self.assertEqual(
-                "can't read /does/not/exist/.env - it doesn't exist",
+                'can\'t read /does/not/exist/.env - it doesn\'t exist',
                 str(w[0].message)
             )
         self.assertFalse('FOO' in self.app.config)
@@ -140,9 +140,8 @@ class DotEnvTestCase(unittest.TestCase):
             root_dir = os.path.dirname(os.path.abspath(__file__))
             self.env._DotEnv__import_vars(os.path.join(root_dir, '.env.min'))
         self.assertIn(
-            " * Setting an entirely new config var: BAR\n"
-            " * Overwriting an existing config var: SECRET_KEY"
-            "\n".format("type" if sys.version_info[0] < 3 else "class"),
+            ' * Setting an entirely new config var: BAR\n'
+            ' * Overwriting an existing config var: SECRET_KEY\n',
             out
         )
 
@@ -151,9 +150,11 @@ class DotEnvTestCase(unittest.TestCase):
             self.env.init_app(self.app)
             self.env.verbose_mode = True
             self.env.eval(keys={'FEATURES': dict})
+
         self.assertIn(
             ' * Casting a specified var as literal:'
-            ' FEATURES => <class \'dict\'>\n',
+            ' FEATURES => <{0} \'dict\'>\n'
+            .format('type' if sys.version_info[0] < 3 else 'class'),
             out
         )
 


### PR DESCRIPTION
I have added `eval()` and maked it as optional.
### Usage

Please set appropriate type as dict argument.

``` py
        @classmethod
        def init_app(self, app)
            env = DotEnv()
            env.init_app(app)

            # this will be evaluated via ast.literal_eval                       
            env.eval(keys={
                MAIL_PORT: int
            })
```
### Output

Improved log messages:

```
* Casting a specified var as literal: MAIL_PORT => <class 'int'>
# (error)
! Could not evaluate as literal type: MAIL_PORT => <class 'int'>
! Does not match with specified type: MAIL_PORT => <class 'int'>
```

cc: @nihonjinrxs 
