### PR TITLE
Suppors export style variable definitions

### DIFF
--- a/flask_dotenv.py
+++ b/flask_dotenv.py
@@ -38,6 +38,7 @@ class DotEnv(object):
             for line in f:
                 try:
                     key, val = line.strip().split('=', 1)
+                    key = key.replace('export ', '')
                 except ValueError:  # Take care of blank or comment lines
                     pass
                 finally:

--- a/tests/.env
+++ b/tests/.env
@@ -5,5 +5,6 @@ TEST_DATABASE_URL='postgresql://user:password@localhost/test'
 DATABASE_URL='postgresql://user:password@localhost/production?sslmode=require'
 # Testing that comments and blank lines are ignored...
 
+export ENV='prod'
 FEATURES={'DotEnv': True}
 PORT_NUMBER=15

--- a/tests/flask_dotenv_test.py
+++ b/tests/flask_dotenv_test.py
@@ -67,17 +67,23 @@ class DotEnvTestCase(unittest.TestCase):
         self.env.init_app(self.app, os.path.join(root_dir, '.env.min'))
         self.assertTrue('BAR' in self.app.config)
 
-    def test_loaded_value_dose_not_contain_double_quote(self):
+    def test_loaded_value_does_not_contain_double_quote(self):
         self.env.init_app(self.app)
         self.assertEqual(
             'postgresql://user:password@localhost/development',
             self.app.config['DEVELOPMENT_DATABASE_URL'])
 
-    def test_loaded_value_dose_not_contain_single_quote(self):
+    def test_loaded_value_does_not_contain_single_quote(self):
         self.env.init_app(self.app)
         self.assertEqual(
             'postgresql://user:password@localhost/test',
             self.app.config['TEST_DATABASE_URL'])
+
+    def test_loaded_value_does_not_contain_export(self):
+        self.env.init_app(self.app)
+        self.assertEqual(
+            'prod',
+            self.app.config['ENV'])
 
     def test_loaded_value_can_contain_equal_signs(self):
         self.env.init_app(self.app)


### PR DESCRIPTION
I'm using dokku to deploy my projects, and it automatically creates a .env file containing its configurations.  
The problem though, is it creates them in export style definitions.  
An example:

```
export DATABASE_URL='postgres://postgres:pass@host:5432/my_db'
export DOKKU_APP_TYPE='herokuish'
export MYAPP_ENV='prod'
```

To support this kind of definition, only a small change is needed and it is backwards compatible.
