### PR TITLE
Lowercased vars

### DIFF
--- a/flask_dotenv.py
+++ b/flask_dotenv.py
@@ -37,8 +37,10 @@ class DotEnv(object):
         with open(env_file, "r") as f:
             for line in f:
                 try:
+                    line = line.lstrip()
+                    if line.startswith('export'):
+                        line = line.replace('export', '',  count=1)
                     key, val = line.strip().split('=', 1)
-                    key = key.lstrip('export ')
                 except ValueError:  # Take care of blank or comment lines
                     pass
                 else:

--- a/flask_dotenv.py
+++ b/flask_dotenv.py
@@ -39,7 +39,7 @@ class DotEnv(object):
                 try:
                     line = line.lstrip()
                     if line.startswith('export'):
-                        line = line.replace('export', '',  count=1)
+                        line = line.replace('export', '', 1)
                     key, val = line.strip().split('=', 1)
                 except ValueError:  # Take care of blank or comment lines
                     pass

--- a/tests/.env
+++ b/tests/.env
@@ -7,6 +7,7 @@ DATABASE_URL='postgresql://user:password@localhost/production?sslmode=require'
 # Testing that comments and blank lines are ignored...
 
 export ENV='prod'
+export env='stag'
 FEATURES={'DotEnv': True}
 PORT_NUMBER=15
 

--- a/tests/flask_dotenv_test.py
+++ b/tests/flask_dotenv_test.py
@@ -84,6 +84,11 @@ class DotEnvTestCase(unittest.TestCase):
         self.assertEqual(
             'prod',
             self.app.config['ENV'])
+        
+        # lowercase
+        self.assertEqual(
+            'stag',
+            self.app.config['env'])
 
     def test_loaded_value_can_contain_equal_signs(self):
         self.env.init_app(self.app)


### PR DESCRIPTION
Small fix for keys that start with lowercased letters 'export'.
>>>'export exp=ort'.lstrip('export ')
'=ort'