### PR TITLE
Add a support for extra spaces around equal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,7 @@ The following lines are all valid.
 
     SECRET_KEY="123"
     USERNAME=john
+    PASSWORD = 'secret'
     DATABASE_URL='postgresql://user:password@localhost/production?sslmode=require'
     FEATURES={'DotEnv': True}
     # comment and blank lines are also supported

--- a/flask_dotenv.py
+++ b/flask_dotenv.py
@@ -36,16 +36,18 @@ class DotEnv(object):
 
     def __import_vars(self, env_file):
         """Actual importing function."""
-        with open(env_file, "r") as f:  # pylint: disable=invalid-name
+        # pylint: disable=invalid-name
+        with open(env_file, "r") as f:
             for line in f:
                 try:
-                    line = line.lstrip()
-                    if line.startswith('export'):
-                        line = line.replace('export', '', 1)
-                    key, val = line.strip().split('=', 1)
+                    t = line.strip()
+                    if t.startswith('export'):
+                        t = t.replace('export', '', 1)
+                    k, v = t.lstrip().split('=', 1)
                 except ValueError:  # Take care of blank or comment lines
                     pass
                 else:
+                    key, val = k.rstrip(), v.lstrip() # Remove extra spaces
                     if not callable(val):
                         if self.verbose_mode:
                             if key in self.app.config:

--- a/tests/.env
+++ b/tests/.env
@@ -11,3 +11,5 @@ export env='stag'
 FEATURES={'DotEnv': True}
 PORT_NUMBER=15
 
+BAZ = 'baz'
+QUX='qux quux'

--- a/tests/flask_dotenv_test.py
+++ b/tests/flask_dotenv_test.py
@@ -46,7 +46,8 @@ class DotEnvTestCase(unittest.TestCase):
             'DATABASE_URL',
             'BAR',
             'FEATURES',
-            'PORT_NUMBER'
+            'PORT_NUMBER',
+            'BAZ',
         ]
         for key in config_keys:
             if key in self.app.config:
@@ -71,6 +72,10 @@ class DotEnvTestCase(unittest.TestCase):
         root_dir = os.path.dirname(os.path.abspath(__file__))
         self.env.init_app(self.app, os.path.join(root_dir, '.env.min'))
         self.assertTrue('BAR' in self.app.config)
+
+    def test_take_value_even_if_extra_spaces_are_given_around_equal(self):
+        self.env.init_app(self.app)
+        self.assertEqual('baz', self.app.config['BAZ'])
 
     def test_loaded_value_does_not_contain_double_quote(self):
         self.env.init_app(self.app)
@@ -100,6 +105,10 @@ class DotEnvTestCase(unittest.TestCase):
         self.assertEqual(
             'postgresql://user:password@localhost/production?sslmode=require',
             self.app.config['DATABASE_URL'])
+
+    def test_loaded_value_can_contain_spaces(self):
+        self.env.init_app(self.app)
+        self.assertEqual('qux quux', self.app.config['QUX'])
 
     def test_overwrite_an_existing_config_var(self):
         # flask has secret_key in default


### PR DESCRIPTION
I've just added extra whitespaces support around equal sign as reported on #17.

```text
Foo='bar'

# for this
BAR = 'baz'
```

This change won't affetct following value which contains whitespaces in it.

```text
QUX='qux quux'
```